### PR TITLE
Move clippy configs defined in Makefile to lints field in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,11 @@ complexity = "warn"
 correctness = "warn"
 suspicious = "warn"
 perf = "warn"
+# We would like to create a return value variable.
+# That makes it easy to add a break point for the return value by debugger.
+let_and_return = { level = "allow", priority = 2 }
+# We would like to write annotate explicitly.
+needless_lifetimes = { level = "allow", priority = 2 }
 
 
 [profile]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,27 @@ rust-version = "1.74"
 [workspace.dependencies]
 fastly = "^0.9.9"
 
+
+[workspace.lints.rust]
+# We would like to more recommend to use rust 2018 idioms
+# See https://doc.rust-lang.org/rustc/lints/groups.html
+rust_2018_idioms = "warn"
+
+[workspace.lints.clippy]
+# We enable clippy rules as same level as `clippy:all` except `clippy:style`.
+# See https://github.com/tetsuharuohzeki/fastly-compute-template/issues/119
+#
+# I think rust-clippy's style rules a bit opinionated
+# and I guess we don't have to enable about it. Hence, we disable it.
+#
+# If we face some problems about sorting a style,
+# then we should rethink to enable `clippy:style`.
+complexity = "warn"
+correctness = "warn"
+suspicious = "warn"
+perf = "warn"
+
+
 [profile]
 [profile.release]
 debug = 1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,5 @@
 [workspace]
-members = [
-    "crates/*",
-]
+members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
@@ -14,6 +12,6 @@ rust-version = "1.74"
 fastly = "^0.9.9"
 
 [profile]
-    [profile.release]
-    debug = 1
-    lto = "thin"
+[profile.release]
+debug = 1
+lto = "thin"

--- a/Makefile
+++ b/Makefile
@@ -69,13 +69,9 @@ endif
 CARGO_FEATURES_CLI_FLAGS := \
     --features $(RELEASE_CHANNEL_FEATURES),$(ADDITIONAL_FEATURES)
 
-CLIPPY_RULES :=
-
-
 # We pass `-Dwarnings` flag to fail all warnings.
 # see https://doc.rust-lang.org/clippy/usage.html#command-line
 CLIPPY_RULES_FAIL_IF_WARNINGS :=\
-    $(CLIPPY_RULES) \
     -Dwarnings
 
 
@@ -157,13 +153,13 @@ __cp_debug_build_to_pkg_dir_in_root: __cargo_build_debug __clean_generated_by_fa
 # Static Analysis
 ###########################
 lint: ## Run static analysis.
-	$(CARGO_BIN) clippy --workspace --all-targets $(CARGO_FEATURES_CLI_FLAGS) -- $(CLIPPY_RULES)
+	$(CARGO_BIN) clippy --workspace --all-targets $(CARGO_FEATURES_CLI_FLAGS)
 
 lint_check: ## Run static analysis and fail if there are some warnings.
 	$(CARGO_BIN) clippy --workspace --all-targets $(CARGO_FEATURES_CLI_FLAGS) -- $(CLIPPY_RULES_FAIL_IF_WARNINGS)
 
 lint_fix: ## Try to fix problems found by static analytics
-	$(CARGO_BIN) clippy --fix --workspace --all-targets $(CARGO_FEATURES_CLI_FLAGS) -- $(CLIPPY_RULES)
+	$(CARGO_BIN) clippy --fix --workspace --all-targets $(CARGO_FEATURES_CLI_FLAGS)
 
 typecheck: ## Validate type and semantics for whole of codes by `cargo check`.
 	$(CARGO_BIN) check --workspace --all-targets --target=$(COMPILE_TARGET_WASM32_WASI) $(CARGO_FEATURES_CLI_FLAGS)

--- a/Makefile
+++ b/Makefile
@@ -69,19 +69,7 @@ endif
 CARGO_FEATURES_CLI_FLAGS := \
     --features $(RELEASE_CHANNEL_FEATURES),$(ADDITIONAL_FEATURES)
 
-# We enable clippy rules as same level as `clippy:all` except `clippy:style`.
-# See https://github.com/tetsuharuohzeki/fastly-compute-template/issues/119
-#
-# I think rust-clippy's style rules a bit opinionated
-# and I guess we don't have to enable about it. Hence, we disable it.
-# If we face some problems about sorting a style,
-# then we should rethink to enable `clippy:style`.
-CLIPPY_RULES := \
-    -W rust-2018-idioms \
-    -W clippy::correctness \
-    -W clippy::suspicious \
-    -W clippy::complexity \
-    -W clippy::perf
+CLIPPY_RULES :=
 
 
 # We pass `-Dwarnings` flag to fail all warnings.

--- a/crates/main/Cargo.toml
+++ b/crates/main/Cargo.toml
@@ -9,7 +9,6 @@ rust-version.workspace = true
 fastly.workspace = true
 
 [features]
-
 # These feature flags represents _release channel_.
 # These are mutually exclusive. You cannot enable both of them.
 production = []

--- a/crates/main/Cargo.toml
+++ b/crates/main/Cargo.toml
@@ -8,6 +8,9 @@ rust-version.workspace = true
 [dependencies]
 fastly.workspace = true
 
+[lints]
+workspace = true
+
 [features]
 # These feature flags represents _release channel_.
 # These are mutually exclusive. You cannot enable both of them.

--- a/crates/main/src/main.rs
+++ b/crates/main/src/main.rs
@@ -1,20 +1,3 @@
-#![warn(
-    // We would like to more recommend to use rust 2018 idioms
-    // See https://doc.rust-lang.org/rustc/lints/groups.html
-    rust_2018_idioms,
-    // We enable clippy rules as same level as `clippy:all` except `clippy:style`.
-    // See https://github.com/tetsuharuohzeki/fastly-compute-template/issues/119
-    //
-    // I think rust-clippy's style rules a bit opinionated
-    // and I guess we don't have to enable about it. Hence, we disable it.
-    //
-    // If we face some problems about sorting a style,
-    // then we should rethink to enable `clippy:style`.
-    clippy::complexity,
-    clippy::correctness,
-    clippy::perf,
-    clippy::suspicious,
-)]
 #![allow(
     // We would like to write annotate explicitly.
     clippy::needless_lifetimes,

--- a/crates/main/src/main.rs
+++ b/crates/main/src/main.rs
@@ -1,11 +1,3 @@
-#![allow(
-    // We would like to write annotate explicitly.
-    clippy::needless_lifetimes,
-    // We would like to create a return value variable.
-    // That makes it easy to add a break point for the return value by debugger.
-    clippy::let_and_return,
-)]
-
 mod application;
 mod build_info;
 mod fastly_trace_id;


### PR DESCRIPTION
Since Rust 1.74, rust toolchain supports `lints` field in Cargo.toml

- https://doc.rust-lang.org/stable/cargo/reference/manifest.html#the-lints-section
- https://doc.rust-lang.org/stable/cargo/reference/workspaces.html#the-lints-table