### PR TITLE
Save cache of dependencies for CI only if on _trunk_ branch

### DIFF
--- a/.github/actions/ci_prepare_npm_for_integration_test/action.yaml
+++ b/.github/actions/ci_prepare_npm_for_integration_test/action.yaml
@@ -8,22 +8,42 @@ runs:
           uses: actions/setup-node@v4
           with:
               node-version: 22
+
         - name: Enable corepack
           run: corepack enable
           shell: bash
+
         - name: Get package manager's cache directory
           id: npm-cache-dir
           shell: bash
           run: echo "dir=$(pnpm store path)" >> $GITHUB_OUTPUT
           # This step should run with pkg manager specied by corepack.
           working-directory: ./integration_tests
-        - name: cache dependencies
-          uses: actions/cache@v4
+
+        - name: Restore dependency caches
+          uses: actions/cache/restore@v4
           id: npm-cache # use this to check for `cache-hit` ==> if: steps.npm-cache.outputs.cache-hit != 'true'
           with:
+              # CAUTION: Match this on the later step.
               path: ${{ steps.npm-cache-dir.outputs.dir }}
-              key: build-v1-${{ runner.os }}-node-pnpm-${{ hashFiles('**/pnpm-lock.yaml') }}
-              restore-keys: |
-                  build-v1-${{ runner.os }}-node-pnpm-${{ hashFiles('**/pnpm-lock.yaml') }}
+              # We use an exact match to avoid to store unnecessary dependencies in the later step.
+              # CAUTION: Match the key name on the later step.
+              key: rev1-node-pnpm-${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
+
         - run: make setup_integration_tests -j
           shell: bash
+
+        - name: Save dependency caches
+          uses: actions/cache/save@v4
+          # We run this step only on _trunk_ to aim to improve a cache hit.
+          # For example, dependabot's pull requests sometimes shoot down a cache hit ratio
+          # by changing a lock file with multiple variants.
+          # Then we cannot reuse cache ideally because the lockfile is changed high frequently under such situation.
+          # Cache utilization is down.
+          # So we give up to save the cache on each of pull requests.
+          if: github.ref == 'refs/heads/main'
+          with:
+              # CAUTION: Match this on the above step.
+              path: ${{ steps.npm-cache-dir.outputs.dir }}
+              # CAUTION: Match the key name on the above step.
+              key: rev1-node-pnpm-${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}

--- a/.github/actions/ci_prepare_to_compile/action.yaml
+++ b/.github/actions/ci_prepare_to_compile/action.yaml
@@ -13,17 +13,39 @@ runs:
               override: true
               cache: true
 
-        - uses: actions/cache@v4
+        - name: Restore dependency caches
+          uses: actions/cache/restore@v4
           with:
               # We can cache ./target/ directory to cache a build intermediate artifacts
               # but then we must add rust toolchain's hash to the cache key.
               # And also, we need to think to add the key to indicate a build profile
+              # CAUTION: Match this on the later step.
               path: |
                   ~/.cargo/
                   !~/.cargo/bin
                   !~/.cargo/env
+              # We use an exact match to avoid to store unnecessary dependencies in the later step.
+              # CAUTION: Match the key name on the later step.
               key: rev1-cargo-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('Cargo.lock') }}
 
         - name: Fetch dependency packages
           shell: bash
           run: cargo fetch --locked
+
+        - name: Save dependency caches
+          uses: actions/cache/save@v4
+          # We run this step only on _trunk_ to aim to improve a cache hit.
+          # For example, dependabot's pull requests sometimes shoot down a cache hit ratio
+          # by changing a lock file with multiple variants.
+          # Then we cannot reuse cache ideally because the lockfile is changed high frequently under such situation.
+          # Cache utilization is down.
+          # So we give up to save the cache on each of pull requests.
+          if: github.ref == 'refs/heads/main'
+          with:
+              # CAUTION: Match this on the above step.
+              path: |
+                  ~/.cargo/
+                  !~/.cargo/bin
+                  !~/.cargo/env
+              # CAUTION: Match the key name on the above step.
+              key: rev1-cargo-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('Cargo.lock') }}


### PR DESCRIPTION
We do this to aim to improve a cache hit.

For example, dependabot's pull requests sometimes shoot down a cache hit ratio by changing a lock file with multiple variants.
hen we cannot reuse cache ideally because the lockfile is changed high frequently under such situation. Cache utilization is down.

So we give up to save the cache on each of pull requests.